### PR TITLE
rebuild gtk3 3.24.21 against harfbuzz 4.3.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels: 
+  cbouss: cairo

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,4 @@
-# update gdk_pixbuf pin for windows (version from conda-forge-pinning doesn't exist)
-gdk_pixbuf:  # [win]
-  - 2.38.2  # [win]
-cdt_name:
-  - amzn2  # [linux and aarch64]
+cairo:
+  - 1.16
+harfbuzz:
+  - 4.3.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
 
 build:
   number: 3
-  skip: True  # [win and vc<14]
+  skip: True  # [not (aarch64 or arm64)]; currently only on these architectures
   # workaround for bug in LIEF (https://github.com/lief-project/LIEF/issues/239)
   # that resulted in missing symbols
   rpaths_patcher: patchelf  # [linux]
@@ -30,6 +30,8 @@ build:
     - '*/libX11.so*'              # [linux]
     - '*/libXext.so*'             # [linux]
     - '/usr/lib/libcups.2.dylib'  # [osx]
+  ignore_run_exports:
+    - pixman
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - no-module-warning.patch
 
 build:
-  number: 2
+  number: 3
   skip: True  # [win and vc<14]
   # workaround for bug in LIEF (https://github.com/lief-project/LIEF/issues/239)
   # that resulted in missing symbols
@@ -171,16 +171,16 @@ test:
     {% endfor %}
 
 about:
-  home: http://www.gtk.org/
+  home: https://www.gtk.org/
   license: LGPL-2.0-or-later
   license_family: LGPL
   license_file: COPYING
-  summary: 'Version 3 of the Gtk+ graphical toolkit'
+  summary: Version 3 of the Gtk+ graphical toolkit
   description: |
     GTK is a multi-platform toolkit for creating graphical user interfaces.
     Offering a complete set of widgets, GTK is suitable for projects ranging
     from small one-off projects to complete application suites.
-  doc_url: https://developer.gnome.org/gtk3/
+  doc_url: https://docs.gtk.org/gtk3/
   dev_url: https://gitlab.gnome.org/GNOME/gtk
 
 extra:


### PR DESCRIPTION
rebuild gtk3 3.24.21 against harfbuzz 4.3.0
qt 5.15.2 depends on gtk3.

Changes:
- add pixman to ignore run exports
- skip all but linux-aarch64 and osx-arm64 (gtk3 has not been built for other archs so far)

TODO: remove cbc and abs.yaml before merging.