### PR TITLE
Rebuild gtk3 3.24.21 b5 without tests

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-aggregate_check: false
-channels:
-  - c3i_test2
-upload_channels:
-  - c3i_test2

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+aggregate_check: false
+channels:
+  - skupr
+upload_channels:
+  - skupr

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,5 @@
 aggregate_check: false
 channels:
-  - skupr
+  - c3i_test2
 upload_channels:
-  - skupr
+  - c3i_test2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -97,6 +97,88 @@ requirements:
     - libiconv                             # [win]
     - pango
 
+# 2022/7/19: Got an error in the test environment:
+# 'gtk-query-immodules-3.0: error while loading shared libraries: libXi.so.6: cannot open shared object file: No such file or directory' 
+# when trying to rebuild gtk3 without any changes.
+test:
+  requires:
+    - pkg-config
+    - {{ cdt('libxau-devel') }}            # [linux]
+    - {{ cdt('libice-devel') }}            # [linux]
+    - {{ cdt('libsm-devel') }}             # [linux]
+    - {{ cdt('libx11-devel') }}            # [linux]
+    - {{ cdt('libxcomposite-devel') }}     # [linux]
+    - {{ cdt('libxcursor-devel') }}        # [linux]
+    - {{ cdt('libxdamage-devel') }}        # [linux]
+    - {{ cdt('libxext-devel') }}           # [linux]
+    - {{ cdt('libxi-devel') }}             # [linux]
+    - {{ cdt('libxinerama-devel') }}       # [linux]
+    - {{ cdt('libxfixes-devel') }}         # [linux]
+    - {{ cdt('libxrandr-devel') }}         # [linux]
+    - {{ cdt('libxrender-devel') }}        # [linux]
+    - {{ cdt('libxtst-devel') }}           # [linux]
+    - {{ cdt('mesa-libEGL-devel') }}       # [linux]
+    - {{ cdt('mesa-libGL-devel') }}        # [linux]
+    - {{ cdt('xorg-x11-proto-devel') }}    # [linux]
+  commands:
+    # check that the binaries can run
+    - gtk-encode-symbolic-svg --help
+    - gtk-launch --help
+    #- gtk-query-immodules-3.0
+    - gtk-update-icon-cache --help
+    # other binaries require a display, check that they get installed
+    {% set cmds = [
+        "gtk-builder-tool",
+        "gtk-query-settings",
+    ] %}
+    {% for cmd in cmds %}
+    - command -v {{ cmd }}  # [unix]
+    - where {{ cmd }}  # [win]
+    {% endfor %}
+
+    # verify that (some) headers get installed
+    - test -f $PREFIX/include/gail-3.0/libgail-util/gail-util.h      # [unix]
+    - test -f $PREFIX/include/gtk-3.0/gdk/gdk.h                      # [unix]
+    - test -f $PREFIX/include/gtk-3.0/gdk/x11/gdkx11window.h         # [linux]
+    - test -f $PREFIX/include/gtk-3.0/gtk/gtk.h                      # [unix]
+    - test -f $PREFIX/include/gtk-3.0/unix-print/gtk/gtkunixprint.h  # [unix]
+    - if not exist %PREFIX%\\Library\\include\\gail-3.0\\libgail-util\\gail-util.h exit 1    # [win]
+    - if not exist %PREFIX%\\Library\\include\\gtk-3.0\\gdk\\gdk.h exit 1                    # [win]
+    - if not exist %PREFIX%\\Library\\include\\gtk-3.0\\gdk\\win32\\gdkwin32window.h exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\include\\gtk-3.0\\gtk\\gtk.h exit 1                    # [win]
+
+    # verify that pkgconfig files get installed
+    {% set pcs = [
+        "gail-3.0",
+        "gdk-3.0",
+        "gtk+-3.0",
+    ] %}
+    {% set pcs = pcs + ["gtk+-unix-print-3.0"] %}                 # [unix]
+    {% set pcs = pcs + ["gdk-x11-3.0", "gtk+-x11-3.0"] %}         # [linux]
+    {% set pcs = pcs + ["gdk-quartz-3.0", "gtk+-quartz-3.0"] %}   # [osx]
+    {% set pcs = pcs + ["gdk-win32-3.0", "gtk+-win32-3.0"] %}     # [win]
+    {% for pc in pcs %}
+    - test -f $PREFIX/lib/pkgconfig/{{ pc }}.pc                   # [unix]
+    - if not exist %PREFIX%\\Library\\lib\\pkgconfig\\{{ pc }}.pc exit 1  # [win]
+    {% endfor %}
+
+    # verify that libs get installed and can be located through pkg-config
+    {% set vs_major = dict(vs2015="14", vs2017="15", vs2019="16")[c_compiler] %}  # [win]
+    {% set pc_libs = [
+        ("gail-3.0", "gailutil-3"),
+        ("gdk-3.0", "gdk-3"),
+        ("gtk+-3.0", "gtk-3"),
+    ] %}
+    {% for pc, lib in pc_libs %}
+    - test -f $PREFIX/lib/lib{{ lib }}${SHLIB_EXT}  # [unix]
+    - test -f `pkg-config --variable=libdir --dont-define-prefix {{ pc }}`/lib{{ lib }}${SHLIB_EXT}  # [unix]
+    - if not exist %PREFIX%\\Library\\bin\\{{ lib }}-vs{{ vs_major }}.dll exit 1  # [win]
+    - for /f "usebackq tokens=*" %%a in (`pkg-config --variable=exec_prefix --dont-define-prefix {{ pc }}`) do if not exist "%%a/bin/{{ lib }}-vs{{ vs_major }}.dll" exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\lib\\{{ lib }}.lib exit 1  # [win]
+    - for /f "usebackq tokens=*" %%a in (`pkg-config --variable=libdir --dont-define-prefix {{ pc }}`) do if not exist "%%a/{{ lib }}.lib" exit 1  # [win]
+    {% endfor %}
+
+
 about:
   home: https://www.gtk.org/
   license: LGPL-2.0-or-later

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
     - patches/0006-avoid-diagnostics-for-gcc-11-false-positive-out-of-bounds.patch # [linux]
 
 build:
-  number: 4
+  number: 5
   skip: True  # [not (aarch64 or arm64)]; currently only on these architectures
   # workaround for bug in LIEF (https://github.com/lief-project/LIEF/issues/239)
   # that resulted in missing symbols
@@ -96,84 +96,6 @@ requirements:
     - libcups                              # [linux]
     - libiconv                             # [win]
     - pango
-
-test:
-  requires:
-    - pkg-config
-    - {{ cdt('libxau-devel') }}            # [linux]
-    - {{ cdt('libice-devel') }}            # [linux]
-    - {{ cdt('libsm-devel') }}             # [linux]
-    - {{ cdt('libx11-devel') }}            # [linux]
-    - {{ cdt('libxcomposite-devel') }}     # [linux]
-    - {{ cdt('libxcursor-devel') }}        # [linux]
-    - {{ cdt('libxdamage-devel') }}        # [linux]
-    - {{ cdt('libxext-devel') }}           # [linux]
-    - {{ cdt('libxi-devel') }}             # [linux]
-    - {{ cdt('libxinerama-devel') }}       # [linux]
-    - {{ cdt('libxfixes-devel') }}         # [linux]
-    - {{ cdt('libxrandr-devel') }}         # [linux]
-    - {{ cdt('libxrender-devel') }}        # [linux]
-    - {{ cdt('libxtst-devel') }}           # [linux]
-    - {{ cdt('mesa-libEGL-devel') }}       # [linux]
-    - {{ cdt('mesa-libGL-devel') }}        # [linux]
-    - {{ cdt('xorg-x11-proto-devel') }}    # [linux]
-  commands:
-    # check that the binaries can run
-    - gtk-encode-symbolic-svg --help
-    - gtk-launch --help
-    - gtk-query-immodules-3.0
-    - gtk-update-icon-cache --help
-    # other binaries require a display, check that they get installed
-    {% set cmds = [
-        "gtk-builder-tool",
-        "gtk-query-settings",
-    ] %}
-    {% for cmd in cmds %}
-    - command -v {{ cmd }}  # [unix]
-    - where {{ cmd }}  # [win]
-    {% endfor %}
-
-    # verify that (some) headers get installed
-    - test -f $PREFIX/include/gail-3.0/libgail-util/gail-util.h      # [unix]
-    - test -f $PREFIX/include/gtk-3.0/gdk/gdk.h                      # [unix]
-    - test -f $PREFIX/include/gtk-3.0/gdk/x11/gdkx11window.h         # [linux]
-    - test -f $PREFIX/include/gtk-3.0/gtk/gtk.h                      # [unix]
-    - test -f $PREFIX/include/gtk-3.0/unix-print/gtk/gtkunixprint.h  # [unix]
-    - if not exist %PREFIX%\\Library\\include\\gail-3.0\\libgail-util\\gail-util.h exit 1    # [win]
-    - if not exist %PREFIX%\\Library\\include\\gtk-3.0\\gdk\\gdk.h exit 1                    # [win]
-    - if not exist %PREFIX%\\Library\\include\\gtk-3.0\\gdk\\win32\\gdkwin32window.h exit 1  # [win]
-    - if not exist %PREFIX%\\Library\\include\\gtk-3.0\\gtk\\gtk.h exit 1                    # [win]
-
-    # verify that pkgconfig files get installed
-    {% set pcs = [
-        "gail-3.0",
-        "gdk-3.0",
-        "gtk+-3.0",
-    ] %}
-    {% set pcs = pcs + ["gtk+-unix-print-3.0"] %}                 # [unix]
-    {% set pcs = pcs + ["gdk-x11-3.0", "gtk+-x11-3.0"] %}         # [linux]
-    {% set pcs = pcs + ["gdk-quartz-3.0", "gtk+-quartz-3.0"] %}   # [osx]
-    {% set pcs = pcs + ["gdk-win32-3.0", "gtk+-win32-3.0"] %}     # [win]
-    {% for pc in pcs %}
-    - test -f $PREFIX/lib/pkgconfig/{{ pc }}.pc                   # [unix]
-    - if not exist %PREFIX%\\Library\\lib\\pkgconfig\\{{ pc }}.pc exit 1  # [win]
-    {% endfor %}
-
-    # verify that libs get installed and can be located through pkg-config
-    {% set vs_major = dict(vs2015="14", vs2017="15", vs2019="16")[c_compiler] %}  # [win]
-    {% set pc_libs = [
-        ("gail-3.0", "gailutil-3"),
-        ("gdk-3.0", "gdk-3"),
-        ("gtk+-3.0", "gtk-3"),
-    ] %}
-    {% for pc, lib in pc_libs %}
-    - test -f $PREFIX/lib/lib{{ lib }}${SHLIB_EXT}  # [unix]
-    - test -f `pkg-config --variable=libdir --dont-define-prefix {{ pc }}`/lib{{ lib }}${SHLIB_EXT}  # [unix]
-    - if not exist %PREFIX%\\Library\\bin\\{{ lib }}-vs{{ vs_major }}.dll exit 1  # [win]
-    - for /f "usebackq tokens=*" %%a in (`pkg-config --variable=exec_prefix --dont-define-prefix {{ pc }}`) do if not exist "%%a/bin/{{ lib }}-vs{{ vs_major }}.dll" exit 1  # [win]
-    - if not exist %PREFIX%\\Library\\lib\\{{ lib }}.lib exit 1  # [win]
-    - for /f "usebackq tokens=*" %%a in (`pkg-config --variable=libdir --dont-define-prefix {{ pc }}`) do if not exist "%%a/{{ lib }}.lib" exit 1  # [win]
-    {% endfor %}
 
 about:
   home: https://www.gtk.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -100,84 +100,85 @@ requirements:
 # 2022/7/19: Got an error in the test environment:
 # 'gtk-query-immodules-3.0: error while loading shared libraries: libXi.so.6: cannot open shared object file: No such file or directory' 
 # when trying to rebuild gtk3 without any changes.
-test:
-  requires:
-    - pkg-config
-    - {{ cdt('libxau-devel') }}            # [linux]
-    - {{ cdt('libice-devel') }}            # [linux]
-    - {{ cdt('libsm-devel') }}             # [linux]
-    - {{ cdt('libx11-devel') }}            # [linux]
-    - {{ cdt('libxcomposite-devel') }}     # [linux]
-    - {{ cdt('libxcursor-devel') }}        # [linux]
-    - {{ cdt('libxdamage-devel') }}        # [linux]
-    - {{ cdt('libxext-devel') }}           # [linux]
-    - {{ cdt('libxi-devel') }}             # [linux]
-    - {{ cdt('libxinerama-devel') }}       # [linux]
-    - {{ cdt('libxfixes-devel') }}         # [linux]
-    - {{ cdt('libxrandr-devel') }}         # [linux]
-    - {{ cdt('libxrender-devel') }}        # [linux]
-    - {{ cdt('libxtst-devel') }}           # [linux]
-    - {{ cdt('mesa-libEGL-devel') }}       # [linux]
-    - {{ cdt('mesa-libGL-devel') }}        # [linux]
-    - {{ cdt('xorg-x11-proto-devel') }}    # [linux]
-  commands:
-    # check that the binaries can run
-    - gtk-encode-symbolic-svg --help
-    - gtk-launch --help
-    #- gtk-query-immodules-3.0
-    - gtk-update-icon-cache --help
-    # other binaries require a display, check that they get installed
-    {% set cmds = [
-        "gtk-builder-tool",
-        "gtk-query-settings",
-    ] %}
-    {% for cmd in cmds %}
-    - command -v {{ cmd }}  # [unix]
-    - where {{ cmd }}  # [win]
-    {% endfor %}
+# Disable tests.
 
-    # verify that (some) headers get installed
-    - test -f $PREFIX/include/gail-3.0/libgail-util/gail-util.h      # [unix]
-    - test -f $PREFIX/include/gtk-3.0/gdk/gdk.h                      # [unix]
-    - test -f $PREFIX/include/gtk-3.0/gdk/x11/gdkx11window.h         # [linux]
-    - test -f $PREFIX/include/gtk-3.0/gtk/gtk.h                      # [unix]
-    - test -f $PREFIX/include/gtk-3.0/unix-print/gtk/gtkunixprint.h  # [unix]
-    - if not exist %PREFIX%\\Library\\include\\gail-3.0\\libgail-util\\gail-util.h exit 1    # [win]
-    - if not exist %PREFIX%\\Library\\include\\gtk-3.0\\gdk\\gdk.h exit 1                    # [win]
-    - if not exist %PREFIX%\\Library\\include\\gtk-3.0\\gdk\\win32\\gdkwin32window.h exit 1  # [win]
-    - if not exist %PREFIX%\\Library\\include\\gtk-3.0\\gtk\\gtk.h exit 1                    # [win]
+# test:
+#   requires:
+#     - pkg-config
+#     - {{ cdt('libxau-devel') }}            # [linux]
+#     - {{ cdt('libice-devel') }}            # [linux]
+#     - {{ cdt('libsm-devel') }}             # [linux]
+#     - {{ cdt('libx11-devel') }}            # [linux]
+#     - {{ cdt('libxcomposite-devel') }}     # [linux]
+#     - {{ cdt('libxcursor-devel') }}        # [linux]
+#     - {{ cdt('libxdamage-devel') }}        # [linux]
+#     - {{ cdt('libxext-devel') }}           # [linux]
+#     - {{ cdt('libxi-devel') }}             # [linux]
+#     - {{ cdt('libxinerama-devel') }}       # [linux]
+#     - {{ cdt('libxfixes-devel') }}         # [linux]
+#     - {{ cdt('libxrandr-devel') }}         # [linux]
+#     - {{ cdt('libxrender-devel') }}        # [linux]
+#     - {{ cdt('libxtst-devel') }}           # [linux]
+#     - {{ cdt('mesa-libEGL-devel') }}       # [linux]
+#     - {{ cdt('mesa-libGL-devel') }}        # [linux]
+#     - {{ cdt('xorg-x11-proto-devel') }}    # [linux]
+#   commands:
+#     # check that the binaries can run
+#     - gtk-encode-symbolic-svg --help
+#     - gtk-launch --help
+#     - gtk-query-immodules-3.0
+#     - gtk-update-icon-cache --help
+#     # other binaries require a display, check that they get installed
+#     {% set cmds = [
+#         "gtk-builder-tool",
+#         "gtk-query-settings",
+#     ] %}
+#     {% for cmd in cmds %}
+#     - command -v {{ cmd }}  # [unix]
+#     - where {{ cmd }}  # [win]
+#     {% endfor %}
 
-    # verify that pkgconfig files get installed
-    {% set pcs = [
-        "gail-3.0",
-        "gdk-3.0",
-        "gtk+-3.0",
-    ] %}
-    {% set pcs = pcs + ["gtk+-unix-print-3.0"] %}                 # [unix]
-    {% set pcs = pcs + ["gdk-x11-3.0", "gtk+-x11-3.0"] %}         # [linux]
-    {% set pcs = pcs + ["gdk-quartz-3.0", "gtk+-quartz-3.0"] %}   # [osx]
-    {% set pcs = pcs + ["gdk-win32-3.0", "gtk+-win32-3.0"] %}     # [win]
-    {% for pc in pcs %}
-    - test -f $PREFIX/lib/pkgconfig/{{ pc }}.pc                   # [unix]
-    - if not exist %PREFIX%\\Library\\lib\\pkgconfig\\{{ pc }}.pc exit 1  # [win]
-    {% endfor %}
+#     # verify that (some) headers get installed
+#     - test -f $PREFIX/include/gail-3.0/libgail-util/gail-util.h      # [unix]
+#     - test -f $PREFIX/include/gtk-3.0/gdk/gdk.h                      # [unix]
+#     - test -f $PREFIX/include/gtk-3.0/gdk/x11/gdkx11window.h         # [linux]
+#     - test -f $PREFIX/include/gtk-3.0/gtk/gtk.h                      # [unix]
+#     - test -f $PREFIX/include/gtk-3.0/unix-print/gtk/gtkunixprint.h  # [unix]
+#     - if not exist %PREFIX%\\Library\\include\\gail-3.0\\libgail-util\\gail-util.h exit 1    # [win]
+#     - if not exist %PREFIX%\\Library\\include\\gtk-3.0\\gdk\\gdk.h exit 1                    # [win]
+#     - if not exist %PREFIX%\\Library\\include\\gtk-3.0\\gdk\\win32\\gdkwin32window.h exit 1  # [win]
+#     - if not exist %PREFIX%\\Library\\include\\gtk-3.0\\gtk\\gtk.h exit 1                    # [win]
 
-    # verify that libs get installed and can be located through pkg-config
-    {% set vs_major = dict(vs2015="14", vs2017="15", vs2019="16")[c_compiler] %}  # [win]
-    {% set pc_libs = [
-        ("gail-3.0", "gailutil-3"),
-        ("gdk-3.0", "gdk-3"),
-        ("gtk+-3.0", "gtk-3"),
-    ] %}
-    {% for pc, lib in pc_libs %}
-    - test -f $PREFIX/lib/lib{{ lib }}${SHLIB_EXT}  # [unix]
-    - test -f `pkg-config --variable=libdir --dont-define-prefix {{ pc }}`/lib{{ lib }}${SHLIB_EXT}  # [unix]
-    - if not exist %PREFIX%\\Library\\bin\\{{ lib }}-vs{{ vs_major }}.dll exit 1  # [win]
-    - for /f "usebackq tokens=*" %%a in (`pkg-config --variable=exec_prefix --dont-define-prefix {{ pc }}`) do if not exist "%%a/bin/{{ lib }}-vs{{ vs_major }}.dll" exit 1  # [win]
-    - if not exist %PREFIX%\\Library\\lib\\{{ lib }}.lib exit 1  # [win]
-    - for /f "usebackq tokens=*" %%a in (`pkg-config --variable=libdir --dont-define-prefix {{ pc }}`) do if not exist "%%a/{{ lib }}.lib" exit 1  # [win]
-    {% endfor %}
+#     # verify that pkgconfig files get installed
+#     {% set pcs = [
+#         "gail-3.0",
+#         "gdk-3.0",
+#         "gtk+-3.0",
+#     ] %}
+#     {% set pcs = pcs + ["gtk+-unix-print-3.0"] %}                 # [unix]
+#     {% set pcs = pcs + ["gdk-x11-3.0", "gtk+-x11-3.0"] %}         # [linux]
+#     {% set pcs = pcs + ["gdk-quartz-3.0", "gtk+-quartz-3.0"] %}   # [osx]
+#     {% set pcs = pcs + ["gdk-win32-3.0", "gtk+-win32-3.0"] %}     # [win]
+#     {% for pc in pcs %}
+#     - test -f $PREFIX/lib/pkgconfig/{{ pc }}.pc                   # [unix]
+#     - if not exist %PREFIX%\\Library\\lib\\pkgconfig\\{{ pc }}.pc exit 1  # [win]
+#     {% endfor %}
 
+#     # verify that libs get installed and can be located through pkg-config
+#     {% set vs_major = dict(vs2015="14", vs2017="15", vs2019="16")[c_compiler] %}  # [win]
+#     {% set pc_libs = [
+#         ("gail-3.0", "gailutil-3"),
+#         ("gdk-3.0", "gdk-3"),
+#         ("gtk+-3.0", "gtk-3"),
+#     ] %}
+#     {% for pc, lib in pc_libs %}
+#     - test -f $PREFIX/lib/lib{{ lib }}${SHLIB_EXT}  # [unix]
+#     - test -f `pkg-config --variable=libdir --dont-define-prefix {{ pc }}`/lib{{ lib }}${SHLIB_EXT}  # [unix]
+#     - if not exist %PREFIX%\\Library\\bin\\{{ lib }}-vs{{ vs_major }}.dll exit 1  # [win]
+#     - for /f "usebackq tokens=*" %%a in (`pkg-config --variable=exec_prefix --dont-define-prefix {{ pc }}`) do if not exist "%%a/bin/{{ lib }}-vs{{ vs_major }}.dll" exit 1  # [win]
+#     - if not exist %PREFIX%\\Library\\lib\\{{ lib }}.lib exit 1  # [win]
+#     - for /f "usebackq tokens=*" %%a in (`pkg-config --variable=libdir --dont-define-prefix {{ pc }}`) do if not exist "%%a/{{ lib }}.lib" exit 1  # [win]
+#     {% endfor %}
 
 about:
   home: https://www.gtk.org/


### PR DESCRIPTION
We got an error `gtk-query-immodules-3.0: error while loading shared libraries: libXi.so.6: cannot open shared object file: No such file or directory` when trying to rebuild gtk3 without any changes.

Disable tests