### PR TITLE
gtk3 3.24.21 rebuild for linux

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
 
 build:
   number: 7
-  skip: True  # [win or s390x]; currently only on these architectures
+  skip: True  # [win or s390x]; Not available on these architectures
   # workaround for bug in LIEF (https://github.com/lief-project/LIEF/issues/239)
   # that resulted in missing symbols
   rpaths_patcher: patchelf  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
 
 build:
   number: 7
-  skip: True  # [win]; currently only on these architectures
+  skip: True  # [win or s390x]; currently only on these architectures
   # workaround for bug in LIEF (https://github.com/lief-project/LIEF/issues/239)
   # that resulted in missing symbols
   rpaths_patcher: patchelf  # [linux]
@@ -99,7 +99,7 @@ requirements:
     - pango
 
 # 2022/7/19: Got an error in the test environment:
-# 'gtk-query-immodules-3.0: error while loading shared libraries: libXi.so.6: cannot open shared object file: No such file or directory' 
+# 'gtk-query-immodules-3.0: error while loading shared libraries: libXi.so.6: cannot open shared object file: No such file or directory'
 # when trying to rebuild gtk3 without any changes.
 # Disable tests.
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,8 +20,8 @@ source:
     - patches/0006-avoid-diagnostics-for-gcc-11-false-positive-out-of-bounds.patch  # [linux]
 
 build:
-  number: 6
-  skip: True  # [not (aarch64 or arm64)]; currently only on these architectures
+  number: 7
+  skip: True  # [win]; currently only on these architectures
   # workaround for bug in LIEF (https://github.com/lief-project/LIEF/issues/239)
   # that resulted in missing symbols
   rpaths_patcher: patchelf  # [linux]
@@ -46,8 +46,8 @@ requirements:
     - pthread-stubs                        # [linux]
     - git                                  # [linux]
     - patch                                # [linux]
-    - cmake                                # [linux and aarch64]
-    - cairo                                # [linux and aarch64]
+    - cmake                                # [linux]
+    - cairo                                # [linux]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ cdt('libxau-devel') }}            # [linux]


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-7424](https://anaconda.atlassian.net/browse/PKG-7424)
- [Upstream repository](https://gitlab.gnome.org/GNOME/gtk)
- [Upstream changelog/diff](https://gitlab.gnome.org/GNOME/gtk/-/blob/main/NEWS)

### Explanation of changes:

- Build for linux architectures (not including s390x)
- Raise build number

### Related
- Doing this to in order to build `graphviz` 
- https://github.com/AnacondaRecipes/graphviz-feedstock/pull/11

[PKG-7424]: https://anaconda.atlassian.net/browse/PKG-7424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ